### PR TITLE
flac.md: Reordering and updating options descriptions - and some of the examples

### DIFF
--- a/man/flac.md
+++ b/man/flac.md
@@ -125,33 +125,27 @@ Some common **encoding** tasks using flac:
 :	Like above, except abc.wav is deleted if there were no errors.
 
 `flac --delete-input-file -w abc.wav`
-:	Like above, except abc.wav is deleted if there were no errors or warnings.
+:	Like above, except abc.wav is deleted if there were no errors and no warnings.
 
-`flac --best abc.wav`
-:	Encode abc.wav to abc.flac using the highest compression setting.
+`flac --best abc.wav` or `flac -8 abc.wav`
+:	Encode abc.wav to abc.flac using the highest compression preset.  
 
-`flac --verify abc.wav`
+`flac --verify abc.wav` or `flac -V abc.wav`
 :	Encode abc.wav to abc.flac and internally decode abc.flac to make sure it matches abc.wav.
 
 `flac -o my.flac abc.wav`
 :	Encode abc.wav to my.flac.
 
 `flac -T "TITLE=Bohemian Rhapsody" -T "ARTIST=Queen" abc.wav`
-:	Encode abc.wav and add some tags at the same time to abc.flac.
+:	Encode abc.wav and add some tags at the same time, to abc.flac.
 
-`flac *.wav`
-:	Encode all .wav files in the current directory.
+`flac abc.aiff foo.rf64 bar.w64`
+:	Encode abc.aiff to abc.flac, foo.rf64 to foo.flac and bar.w64 to bar.flac
 
-`flac abc.aiff`
-:	Encode abc.aiff to abc.flac.
+`flac *.wav *.aif`
+:	Encode all .wav files and all .aif files in the current directory.
 
-`flac abc.rf64`
-:	Encode abc.rf64 to abc.flac.
-
-`flac abc.w64`
-:	Encode abc.w64 to abc.flac.
-
-`flac abc.flac --force`
+`flac abc.flac --force` or `flac abc.flac -f`
 :	This one's a little tricky: notice that flac is in encode mode by
 	default (you have to specify -d to decode) so this command actually
 	recompresses abc.flac back to abc.flac. \--force is needed to make
@@ -159,30 +153,41 @@ Some common **encoding** tasks using flac:
 	would you want to do this? It allows you to recompress an existing
 	FLAC file with (usually) higher compression options or a newer
 	version of FLAC and preserve all the metadata like tags too.
+ 	Note: If the FLAC file does not end with .flac - say, it is abc.fla
+  	- then a new abc.flac will be created and the old kept, just like 
+   	for an uncompressed input file.
+
+`flac -8Vfo Track04.flac -T "ARTIST=Queen" -- -4.wav`
+:	Options in their short version - those invoked with single dash - 
+	can be concatenated until one that takes an argument: here -o and 
+ 	-T do, and so one of them requires its own dash. 
+	This command line takes the track -4.wav as input; its filename 
+ 	starts with a dash, so it needs the \-- to keep the encoder from
+  	taking the "4" as an option. All options must go before the --: 
+        It will overwrite any Track04.flac already present, encode with
+	highest compression preset, decode to verify that it matches, and 
+ 	a tag will be added. 
+
 
 Some common **decoding** tasks using flac:
 
-`flac -d abc.flac`
+`flac --decode abc.flac` or `flac -d abc.flac`
 :	Decode abc.flac to abc.wav. abc.flac is not deleted. NOTE: Without 
-	-d it means re-encode abc.flac to abc.flac (see above).
+	-d it would mean to re-encode abc.flac to abc.flac (see above) and 
+ 	would err out because abc.flac already exists.
 
-`flac -d --force-aiff-format abc.flac`  
-
-`flac -d -o abc.aiff abc.flac`
+`flac -d --force-aiff-format abc.flac` or `flac -d -o abc.aiff abc.flac`
 :	Two different ways of decoding abc.flac to abc.aiff (AIFF format).
-	abc.flac is not deleted.
+	abc.flac is not deleted. -d -o could be concatenated to -do.
+ 	The decoder can force other output formats, see the options below.
 
-`flac -d --force-rf64-format abc.flac`  
-
-`flac -d -o abc.rf64 abc.flac`
-:	Two different ways of decoding abc.flac to abc.rf64 (RF64 format).
-	abc.flac is not deleted.
-
-`flac -d --force-wave64-format abc.flac`  
-
-`flac -d -o abc.w64 abc.flac`
-:	Two different ways of decoding abc.flac to abc.w64 (Wave64 format).
-	abc.flac is not deleted.
+`flac -d --keep-foreign-metadata-if-present abc.flac`
+:	FLAC files can store non-audio chunks of input WAVE/AIFF/RF64/W64
+	files. If there are such chunks stored, the decoder will select
+ 	output format accordingly and restore both audio and non-audio.
+  	If there are no such chunks stored, it will decode to abc.wav.
+   	The related option \--keep-foreign-metadata will instead exit 
+    	with an error if no such non-audio chunks are found.
 
 `flac -d -F abc.flac`
 :	Decode abc.flac to abc.wav and don't abort if errors are found
@@ -192,18 +197,16 @@ Some common **decoding** tasks using flac:
 # OPTIONS
 
 A summary of options is included below. For a complete description, see
-the HTML documentation.
+the HTML documentation. Several of the options can be negated, see the 
+**Negative options** section below.
 
 ## GENERAL OPTIONS
 
 **-v, \--version**
-:	Show the flac version number
+:	Show the flac version number, and quit.
 
 **-h, \--help**
-:	Show basic usage and a list of all options
-
-**-H, \--explain**
-:	Show detailed explanation of usage and all options
+:	Show basic usage and a list of all options, and quit.
 
 **-d, \--decode**
 :	Decode (the default behavior is to encode)
@@ -220,45 +223,29 @@ the HTML documentation.
 **-c, \--stdout**
 :	Write output to stdout
 
-**-s, \--silent**
-:	Silent mode (do not write runtime encode/decode statistics to stderr)
-
-**\--totally-silent**
-: Do not print anything of any kind, including warnings or errors. The
-	exit code will be the only way to determine successful completion.
-
-**\--no-utf8-convert**
-:	Do not convert tags from local charset to UTF-8. This is useful for
-	scripts, and setting tags in situations where the locale is wrong.
-	This option must appear before any tag options!
-
-**-w, \--warnings-as-errors**
-:	Treat all warnings as errors (which cause flac to terminate with a
-	non-zero exit code).
-
 **-f, \--force**
 :	Force overwriting of output files. By default, flac warns that the
 	output file already exists and continues to the next file.
-
-**-o** *filename***, \--output-name=***filename*
-:	Force the output file name (usually flac just changes the extension).
-	May only be used when encoding a single file. May not be used in
-	conjunction with \--output-prefix.
-
-**\--output-prefix=***string*
-:	Prefix each output file name with the given string. This can be
-	useful for encoding or decoding files to a different directory. Make
-	sure if your string is a path name that it ends with a trailing \`/'
-	(slash).
 
 **\--delete-input-file**
 :	Automatically delete the input file after a successful encode or
 	decode. If there was an error (including a verify error) the input
 	file is left intact.
 
+**-o** _filename_, **\--output-name=** _filename_
+:	Force the output file name (usually flac just changes the extension).
+	May only be used when encoding a single file. May not be used in
+	conjunction with \--output-prefix.
+
+**\--output-prefix=** _string_
+:	Prefix each output file name with the given string. This can be
+	useful for encoding or decoding files to a different directory. Make
+	sure if your string is a path name that it ends with a trailing \`/'
+	(slash).
+
 **\--preserve-modtime**
-:	Output files have their timestamps/permissions set to match those of
-	their inputs (this is default). Use \--no-preserve-modtime to make
+:	(default!) Output files have their timestamps/permissions set to 
+	match those of their inputs. Use \--no-preserve-modtime to make
 	output files have the current time and default permissions.
 
 **\--keep-foreign-metadata**
@@ -268,20 +255,20 @@ the HTML documentation.
 	transcoded, e.g. WAVE chunks saved in a FLAC file cannot be restored
 	when decoding to AIFF. Input and output must be regular files (not
 	stdin or stdout). With this option, FLAC will pick the right output
-	format on decoding.
+	format on decoding. It will exit with error if no such chunks are found.
 
 **\--keep-foreign-metadata-if-present**
 :	Like \--keep-foreign-metadata, but without throwing an error if
-	foreign metadata cannot be found or restored, instead printing a 
+	foreign metadata cannot be found or restored.  Instead, prints a 
 	warning.
 
-**\--skip={***\#***\|***mm:ss.ss***}**
+**\--skip={**_\#_**\|**_mm:ss.ss_**}**
 :	Skip over the first number of samples of the input. This works for
 	both encoding and decoding, but not testing. The alternative form
 	mm:ss.ss can be used to specify minutes, seconds, and fractions of a
 	second.
 
-**\--until={***\#***\|\[***+***\|***-***\]***mm:ss.ss***}**
+**\--until={**_\#_**\|\[**_+_**\|**_-_**\]**_mm:ss.ss_**}**
 :	Stop at the given sample number for each input file. This works for
 	both encoding and decoding, but not testing. The given sample number
 	is not included in the decoded output. The alternative form mm:ss.ss
@@ -290,36 +277,32 @@ the HTML documentation.
 	relative to the \--skip point. If a \`-' (minus) sign is at the
 	beginning, the \--until point is relative to end of the audio.
 
-**\--ogg**
-:	When encoding, generate Ogg FLAC output instead of native FLAC. Ogg
-	FLAC streams are FLAC streams wrapped in an Ogg transport layer. The
-	resulting file should have an '.oga' extension and will still be
-	decodable by flac. When decoding, force the input to be treated as
-	Ogg FLAC. This is useful when piping input from stdin or when the
-	filename does not end in '.oga' or '.ogg'.
+**\--no-utf8-convert**
+:	Do not convert tags from local charset to UTF-8. This is useful for
+	scripts, and setting tags in situations where the locale is wrong.
+	This option must appear before any tag options!
 
-**\--serial-number=***\#*
-:	When used with \--ogg, specifies the serial number to use for the
-	first Ogg FLAC stream, which is then incremented for each additional
-	stream. When encoding and no serial number is given, flac uses a
-	random number for the first stream, then increments it for each
-	additional stream. When decoding and no number is given, flac uses
-	the serial number of the first page.
+**-s, \--silent**
+:	Silent mode (do not write runtime encode/decode statistics to stderr)
 
-## ANALYSIS OPTIONS
+**\--totally-silent**
+: Do not print anything of any kind, including warnings or errors. The
+	exit code will be the only way to determine successful completion.
 
-**\--residual-text**
-:	Includes the residual signal in the analysis file. This will make the
-	file very big, much larger than even the decoded file.
-
-**\--residual-gnuplot**
-:	Generates a gnuplot file for every subframe; each file will contain
-	the residual distribution of the subframe. This will create a lot of
-	files.
+**-w, \--warnings-as-errors**
+:	Treat all warnings as errors (which cause flac to terminate with a
+	non-zero exit code).
 
 ## DECODING OPTIONS
 
-**\--cue=\[***\#.#***\]\[-\[***\#.#***\]\]**
+**-F, \--decode-through-errors**
+:	By default flac stops decoding with an error and removes the
+	partially decoded file if it encounters a bitstream error. With -F,
+	errors are still printed but flac will continue decoding to
+	completion. Note that errors may cause the decoded audio to be
+	missing some samples or have silent sections.
+
+**\--cue=\[**_\#.#_**\]\[-\[**_\#.#_**\]\]**
 :	Set the beginning and ending cuepoints to decode. The optional first
 	\#.# is the track and index point at which decoding will start; the
 	default is the beginning of the stream. The optional second \#.# is
@@ -332,12 +315,8 @@ the HTML documentation.
 	\--skip and \--until. A CD track can always be cued by, for example,
 	\--cue=9.1-10.1 for track 9, even if the CD has no 10th track.
 
-**-F, \--decode-through-errors**
-:	By default flac stops decoding with an error and removes the
-	partially decoded file if it encounters a bitstream error. With -F,
-	errors are still printed but flac will continue decoding to
-	completion. Note that errors may cause the decoded audio to be
-	missing some samples or have silent sections.
+**--decode-chained-stream**
+: Decode all links in a chained Ogg stream, not just the first one.
 
 **\--apply-replaygain-which-is-not-lossless\[=\<specification\>\]**
 :	Applies ReplayGain values while decoding. **WARNING: THIS IS NOT
@@ -349,9 +328,78 @@ the HTML documentation.
 
 ## ENCODING OPTIONS
 
+Encoding will default to -5, -A "tukey(5e-1)" and one CPU thread.
+
 **-V, \--verify**
 :	Verify a correct encoding by decoding the output in parallel and
-	comparing to the original
+	comparing to the original.
+
+**-0, \--compression-level-0, \--fast**
+:	Fastest compression preset. Synonymous with `-l 0 -b 1152 -r 3 --no-mid-side`
+
+**-1, \--compression-level-1**
+:	Synonymous with `-l 0 -b 1152 -M -r 3`
+
+**-2, \--compression-level-2**
+:	Synonymous with `-l 0 -b 1152 -m -r 3`
+
+**-3, \--compression-level-3**
+:	Synonymous with `-l 6 -b 4096 -r 4 --no-mid-side`
+
+**-4, \--compression-level-4**
+:	Synonymous with `-l 8 -b 4096 -M -r 4`
+
+**-5, \--compression-level-5**
+:	Synonymous with `-l 8 -b 4096 -m -r 5`
+
+**-6, \--compression-level-6**
+:	Synonymous with `-l 8 -b 4096 -m -r 6 -A "subdivide_tukey(2)"`
+
+**-7, \--compression-level-7**
+:	Synonymous with `-l 12 -b 4096 -m -r 6 -A "subdivide_tukey(2)"`
+
+**-8, \--compression-level-8, \--best**
+:	Synonymous with `-l 12 -b 4096 -m -r 6 -A "subdivide_tukey(3)"`
+
+**-l** _\#_**, \--max-lpc-order=**_\#_  
+:	Specifies the maximum LPC order. This number must be \<= 32. For
+	subset streams, it must be \<=12 if the sample rate is \<=48kHz. If
+	0, the encoder will not attempt generic linear prediction, and use
+	only fixed predictors. Using fixed predictors is faster but usually
+	results in files being 5-10% larger.
+
+**-b** _\#_**, \--blocksize=**_\#_  
+:	Specify the blocksize in samples. The default is 1152 for -l 0,
+	else 4096. Blocksize must be between 16 and 65535 (inclusive). 
+ 	For subset streams it must be \<= 4608 if the samplerate is 
+  	\<= 48kHz, for subset streams with higher samplerates it must be \<=
+	16384.
+
+**-m, \--mid-side**
+:	Try mid-side coding for each frame (stereo input only, otherwise ignored)
+
+**-M, \--adaptive-mid-side**
+:	Adaptive mid-side coding for all frames (stereo input only, otherwise ignored)
+
+**-r \[**_\#_**,\]**_\#_**, \--rice-partition-order=\[**_\#_**,\]**_\#_  
+:	Set the \[min,\]max residual partition order (0..15).  For subset streams 
+	max must be \<=8.  min defaults to 0 if unspecified. Default is -r 5.
+
+**-A** _function_**, \--apodization=** _function_  
+:	Window audio data with given the apodization function(s). See section
+	**Apodization functions** for details.
+
+**-e, \--exhaustive-model-search**
+:	Do exhaustive model search (expensive!)
+
+**-q** _\#_**, \--qlp-coeff-precision=**_\#_  
+:	Precision of the quantized linear-predictor coefficients. This number must 
+	be in between 5 and 16, or 0 (default) =\> to encoder decide.  
+ 	Does nothing if using -l 0. 
+
+**-p, \--qlp-coeff-precision-search**
+:	Do exhaustive search of LP coefficient quantization (expensive!).
+	Overrides -q; does nothing if using -l 0
 
 **\--lax**
 :	Allow encoder to generate non-Subset files. The resulting FLAC file
@@ -360,14 +408,27 @@ the HTML documentation.
 	option in combination with custom encoding options meant for
 	archival.
 
-**-j** *\#***, \--threads=***\#*  
+**\--limit-min-bitrate**
+:	Ensure a certain minimum bitrate. This is sometimes needed for 
+	streaming. 
+
+**-j** _\#_**, \--threads=**_\#_  
 :	Try to set a maximum number of threads to use for encoding. If
 	multithreading was not enabled on compilation or when setting a
 	number of threads that is too high, this fails with a warning. The
-	value of 0 is currently equal to 1 thread (i.e. no multithreading)
-	but may mean something else in the future. Currently the maximum
-	supported number of threads is 128. Using a value higher than the
-	number of available CPU threads harms performance.
+	value of 0 means a default set by the encoder; currently that is 1 
+ 	thread (i.e. no multithreading), but that could change in the 
+  	future.  Currently, up to 128 threads are supported. Using a value 
+   	higher than the number of available CPU threads harms performance.
+
+**\--ignore-chunk-sizes**
+:	When encoding to flac, ignore the file size headers in WAV and AIFF
+	files to attempt to work around problems with over-sized or malformed
+	files. WAV and AIFF files both specifies length of audio data with
+ 	an unsigned 32-bit number, limiting audio to just over 4 gigabytes. 
+  	Files larger than this are malformed, but should be read correctly 
+   	using this option. However, it could interpret any data following
+    	the audio chunk, as audio.
 
 **\--replay-gain**
 :	Calculate ReplayGain values and store them as FLAC tags, similar to
@@ -383,13 +444,13 @@ the HTML documentation.
 	are processed. Note that this option cannot be used when encoding
 	to standard output (stdout).
 
-**\--cuesheet=***filename*  
+**\--cuesheet=**_filename_  
 :	Import the given cuesheet file and store it in a CUESHEET metadata
 	block. This option may only be used when encoding a single file. A
 	seekpoint will be added for each index point in the cuesheet to the
 	SEEKTABLE unless \--no-cued-seekpoints is specified.
 
-**\--picture={***FILENAME***\|***SPECIFICATION***}**
+**\--picture={**_FILENAME_**\|**_SPECIFICATION_**}**
 :	Import a picture and store it in a PICTURE metadata block. More than
 	one \--picture option can be specified. Either a filename for the
 	picture file or a more complete specification form can be used. The
@@ -398,16 +459,7 @@ the HTML documentation.
 	FILENAME is just shorthand for "\|\|\|\|FILENAME". For the format of
 	SPECIFICATION, see the section **picture specification**.
 
-**\--ignore-chunk-sizes**
-:	When encoding to flac, ignore the file size headers in WAV and AIFF
-	files to attempt to work around problems with over-sized or malformed
-	files. WAV and AIFF files both have an unsigned 32 bit numbers in
-	the file header which specifes the length of audio data. Since this
-	number is unsigned 32 bits, that limits the size of a valid file to
-	being just over 4 Gigabytes. Files larger than this are mal-formed,
-	but should be read correctly using this option.
-
-**-S {***\#***\|***X***\|***\#x***\|***\#s***}, \--seekpoint={***\#***\|***X***\|***\#x***\|***\#s***}**
+**-S {**_\#_**\|**_X_**\|**_\#x_**\|**_\#s_**}, \--seekpoint={**_\#_**\|**_X_**\|**_\#x_**\|**_\#s_**}**
 :	Include a point or points in a SEEKTABLE. Using \#, a seek point at
 	that sample number is added. Using X, a placeholder point is added at
 	the end of a the table. Using \#x, \# evenly spaced seek points will
@@ -423,162 +475,118 @@ the HTML documentation.
 	size is determinable before encoding starts) or a placeholder point
 	(if input size is not determinable).
 
-**-P** *\#***, \--padding=***\#*  
-:	Tell the encoder to write a PADDING metadata block of the given
-	length (in bytes) after the STREAMINFO block. This is useful if you
-	plan to tag the file later with an APPLICATION block; instead of
-	having to rewrite the entire file later just to insert your block,
-	you can write directly over the PADDING block. Note that the total
-	length of the PADDING block will be 4 bytes longer than the length
-	given because of the 4 metadata block header bytes. You can force no
-	PADDING block at all to be written with \--no-padding. The encoder
-	writes a PADDING block of 8192 bytes by default (or 65536 bytes if
-	the input audio stream is more that 20 minutes long).
+**-P** _\#_**, \--padding=**_\#_  
+:	(default: 8192 bytes, although 65536 for input audio above 20 minutes) 
+	Tell the encoder to write a PADDING metadata block of the given
+	length (in bytes) after the STREAMINFO block. This is useful for 
+ 	later tagging, where one can write over the PADDING block instead 
+  	of having to rewrite the entire file. Note that a block header 
+        of 4 bytes will come on top of the length specified.
 
-**-T** *FIELD=VALUE***, \--tag=***FIELD=VALUE*  
+**-T** "_FIELD=VALUE_"**, \--tag=**"_FIELD=VALUE_"  
 :	Add a FLAC tag. The comment must adhere to the Vorbis comment spec;
 	i.e. the FIELD must contain only legal characters, terminated by an
 	'equals' sign. Make sure to quote the comment if necessary. This
-	option may appear more than once to add several comments. NOTE: all
-	tags will be added to all encoded files.
+	option may appear more than once to add several comments. 
+ 	NOTE: all tags will be added to all encoded files.
 
-**\--tag-from-file=***FIELD=FILENAME*  
+**\--tag-from-file=**_FIELD=FILENAME_  
 :	Like \--tag, except FILENAME is a file whose contents will be read
 	verbatim to set the tag value. The contents will be converted to
 	UTF-8 from the local charset. This can be used to store a cuesheet
 	in a tag (e.g. \--tag-from-file="CUESHEET=image.cue"). Do not try to
 	store binary data in tag fields! Use APPLICATION blocks for that.
 
-**-b** *\#***, \--blocksize=***\#*  
-:	Specify the blocksize in samples. The default is 1152 for -l 0,
-	else 4096. For subset streams this must be \<= 4608 if the samplerate
-	\<= 48kHz, for subset streams with higher samplerates it must be \<=
-	16384.
-
-**-m, \--mid-side**
-:	Try mid-side coding for each frame (stereo input only)
-
-**-M, \--adaptive-mid-side**
-:	Adaptive mid-side coding for all frames (stereo input only)
-
-**-0..-8, \--compression-level-0..\--compression-level-8**
-:	Fastest compression..highest compression (default is -5). These are
-	synonyms for other options:
-
-**-0, \--compression-level-0**
-:	Synonymous with -l 0 -b 1152 -r 3 \--no-mid-side
-
-**-1, \--compression-level-1**
-:	Synonymous with -l 0 -b 1152 -M -r 3
-
-**-2, \--compression-level-2**
-:	Synonymous with -l 0 -b 1152 -m -r 3
-
-**-3, \--compression-level-3**
-:	Synonymous with -l 6 -b 4096 -r 4 \--no-mid-side
-
-**-4, \--compression-level-4**
-:	Synonymous with -l 8 -b 4096 -M -r 4
-
-**-5, \--compression-level-5**
-:	Synonymous with -l 8 -b 4096 -m -r 5
-
-**-6, \--compression-level-6**
-:	Synonymous with -l 8 -b 4096 -m -r 6 -A subdivide_tukey(2)
-
-**-7, \--compression-level-7**
-:	Synonymous with -l 12 -b 4096 -m -r 6 -A subdivide_tukey(2)
-
-**-8, \--compression-level-8**
-:	Synonymous with -l 12 -b 4096 -m -r 6 -A subdivide_tukey(3)
-
-**\--fast**
-:	Fastest compression. Currently synonymous with -0.
-
-**\--best**
-:	Highest compression. Currently synonymous with -8.
-
-**-e, \--exhaustive-model-search**
-:	Do exhaustive model search (expensive!)
-
-**-A** *function***, \--apodization=***function*  
-:	Window audio data with given the apodization function. See section
-	**Apodization functions** for details.
-
-**-l** *\#***, \--max-lpc-order=***\#*  
-:	Specifies the maximum LPC order. This number must be \<= 32. For
-	subset streams, it must be \<=12 if the sample rate is \<=48kHz. If
-	0, the encoder will not attempt generic linear prediction, and use
-	only fixed predictors. Using fixed predictors is faster but usually
-	results in files being 5-10% larger.
-
-**-p, \--qlp-coeff-precision-search**
-:	Do exhaustive search of LP coefficient quantization (expensive!).
-	Overrides -q; does nothing if using -l 0
-
-**-q** *\#***, \--qlp-coeff-precision=***\#*  
-:	Precision of the quantized linear-predictor coefficients, 0 =\> let
-	encoder decide (min is 5, default is 0)
-
-**-r \[***\#***,\]***\#***, \--rice-partition-order=\[***\#***,\]***\#*  
-:	Set the \[min,\]max residual partition order (0..15). min defaults to
-	0 if unspecified. Default is -r 5.
 
 ## FORMAT OPTIONS
 
-**\--endian={***big***\|***little***}**
-:	Set the byte order for samples
+Encoding defaults to FLAC and not OGG.  Decoding defaults to WAVE (more
+specifically WAVE_FORMAT_PCM for mono/stereo with 8/16 bits, and to 
+WAVE_FORMAT_EXTENSIBLE otherwise), except: will be overridden by chunks 
+found by \--keep-foreign-metadata-if-present or \--keep-foreign-metadata 
 
-**\--channels=***\#*
-:	Set number of channels.
+**\--ogg**
+:	When encoding, generate Ogg FLAC output instead of native FLAC. Ogg
+	FLAC streams are FLAC streams wrapped in an Ogg transport layer. The
+	resulting file should have an '.oga' extension and will still be
+	decodable by flac. When decoding, force the input to be treated as
+	Ogg FLAC. This is useful when piping input from stdin or when the
+	filename does not end in '.oga' or '.ogg'.
 
-**\--bps=***\#*
-:	Set bits per sample.
-
-**\--sample-rate=***\#*
-:	Set sample rate (in Hz).
-
-**\--sign={***signed***\|***unsigned***}**
-:	Set the sign of samples.
-
-**\--input-size=***\#*
-:	Specify the size of the raw input in bytes. If you are encoding raw
-	samples from stdin, you must set this option in order to be able to
-	use \--skip, \--until, \--cuesheet, or other options that need to
-	know the size of the input beforehand. If the size given is greater
-	than what is found in the input stream, the encoder will complain
-	about an unexpected end-of-file. If the size given is less, samples
-	will be truncated.
-
-**\--force-raw-format**
-:	Force input (when encoding) or output (when decoding) to be treated
-	as raw samples (even if filename ends in *.wav*).
+**\--serial-number=**_\#_
+:	When used with \--ogg, specifies the serial number to use for the
+	first Ogg FLAC stream, which is then incremented for each additional
+	stream. When encoding and no serial number is given, flac uses a
+	random number for the first stream, then increments it for each
+	additional stream. When decoding and no number is given, flac uses
+	the serial number of the first page.
 
 **\--force-aiff-format**  
 **\--force-rf64-format**  
 **\--force-wave64-format**
-:	Force the decoder to output AIFF/RF64/WAVE64 format respectively.
+:	For decoding: Override default output format and force output to 
+	AIFF/RF64/WAVE64, respectively.
 	This option is not needed if the output filename (as set by -o) 
-	ends with *.aif* or *.aiff*, *.rf64* and *.w64* respectively. Also,
-	this option has no effect when encoding since input is
-	auto-detected. When none of these options nor 
-	\--keep-foreign-metadata are given and no output filename is set,
-	the output format is WAV by default.
+	ends with *.aif* or *.aiff*, *.rf64* and *.w64* respectively. 
+ 	The encoder auto-detects format and ignores this option. 
 
 **\--force-legacy-wave-format**  
 **\--force-extensible-wave-format**
 :	Instruct the decoder to output a WAVE file with WAVE_FORMAT_PCM and
-	WAVE_FORMAT_EXTENSIBLE respectively. If none of these options nor
-	\--keep-foreign-metadata are given, FLAC outputs WAVE_FORMAT_PCM
-	for mono or stereo with a bit depth of 8 or 16 bits, and
-	WAVE_FORMAT_EXTENSIBLE for all other audio formats.
+	WAVE_FORMAT_EXTENSIBLE respectively, overriding default choice.
 
 **\--force-aiff-c-none-format**  
 **\--force-aiff-c-sowt-format**
 :	Instruct the decoder to output an AIFF-C file with format NONE and
 	sowt respectively.
 
+**\--force-raw-format**
+:	Force input (when encoding) or output (when decoding) to be treated
+	as raw samples (even if filename suggests otherwise).
+
+### raw format options
+
+When encoding from or decoding to raw PCM, format must be specified.
+
+**\--sign={**_signed_**\|**_unsigned_**}**
+:	Specify the sign of samples.
+
+**\--endian={**_big_**\|**_little_**}**
+:	Specify the byte order for samples
+
+**\--channels=**_\#_
+:	(Input only) specify number of channels.  For output, the channels 
+	of the FLAC file will be written interleaved. 
+
+**\--bps=**_\#_
+:	(Input only) specify bits per sample (per channel: 16 for CDDA.)
+
+**\--sample-rate=**_\#_
+:	(Input only) specify sample rate (in Hz).
+
+**\--input-size=**_\#_
+:	(Input only) specify the size of the raw input in bytes.  This is only
+	compulsory when encoding from stdin and using options that need to 
+ 	know the input size beforehand (like, \--skip, \--until, \--cuesheet )
+	The encoder will truncate at the specified size if the input stream is
+ 	bigger.  If the input stream is smaller, it will complain about an 
+  	unexpected end-of-file. 
+
+## ANALYSIS OPTIONS
+
+**\--residual-text**
+:	Includes the residual signal in the analysis file. This will make the
+	file very big, much larger than even the decoded file.
+
+**\--residual-gnuplot**
+:	Generates a gnuplot file for every subframe; each file will contain
+	the residual distribution of the subframe. This will create a lot of
+	files. gnuplot must be installed separately. 
+
+
 ## NEGATIVE OPTIONS
+
+The following will negate an option previously given:
 
 **\--no-adaptive-mid-side**  
 **\--no-cued-seekpoints**  
@@ -601,11 +609,9 @@ the HTML documentation.
 **\--no-verify**  
 **\--no-warnings-as-errors**
 
-These flags can be used to invert the sense of the corresponding normal
-option.
 
 ## ReplayGain application specification
-The option \--apply-replaygain-which-is-not-lossless\[=\<specification\>\]**
+The option \--apply-replaygain-which-is-not-lossless\[=\<specification\>\]
 applies ReplayGain values while decoding. **WARNING: THIS IS NOT
 LOSSLESS. DECODED AUDIO WILL NOT BE IDENTICAL TO THE ORIGINAL WITH THIS
 OPTION.** This option is useful for example in transcoding media servers,


### PR DESCRIPTION
I am not sure about the organization of the initial part of the document, to be honest. For example the way it promises examples before options, but before the examples sections it gives examples (on using stdin).

Anyway, here are the most significant changes I made: 
- Some in the examples
- Options are reorganized to match the flac -h order 
- I used _underscores_ for italics, avoiding some formatting issue that arose from triple asterisks 
- Some " " inserted - you will all too easily need them when using -T - but I dared not use too many of them. 

... and some more text tweaks. 